### PR TITLE
Fixed signup login navigation

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -4,7 +4,7 @@ import LottieView from 'lottie-react-native';
 import { useRouter } from "expo-router";
 
 const HomeScreen: React.FC = () => {
-  const router = useRouter();  
+  const router = useRouter();
 
   const handleLoginPress = () => {
     router.push("/login");

--- a/mobile/app/login.tsx
+++ b/mobile/app/login.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 import LottieView from 'lottie-react-native';
-import { Ionicons } from '@expo/vector-icons'; 
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from "expo-router";
 
 const LoginScreen = () => {
+  const router = useRouter();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false); 
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleLogin = () => {
-    console.log('Username:', username, 'Password:', password);
+    router.push("/(tabs)");
   };
 
   const handleForgotPassword = () => {


### PR DESCRIPTION
Renamed `home` to `index` and index can redirect to login page which redirects to the main tabs on successful login.

Closes #432.